### PR TITLE
Fix "unreadable content" error when opening generated file

### DIFF
--- a/lib/caracal/renderers/relationships_renderer.rb
+++ b/lib/caracal/renderers/relationships_renderer.rb
@@ -19,7 +19,7 @@ module Caracal
           xml.send 'Relationships', root_options do
             document.relationships.each do |rel|
               if rel.relationship_type == :font_file
-                xml.send 'Relationship', font_file_rel_options(rel)
+                # xml.send 'Relationship', font_file_rel_options(rel)
                 
                 next
               end


### PR DESCRIPTION
Comment out font file renderer in document.xml.rels.